### PR TITLE
feat: diskcache API facade with five-backend test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,15 +27,20 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
 
       - name: Setup Plone Buildout
         uses: ./.github/actions/setup-plone-buildout
 
+      - name: Cache database container images
+        run: docker pull postgres:16 && docker pull mysql:8
+
       - name: Run unit tests
         run: make test
+        env:
+          RUN_DB_CONTAINER_TESTS: "1"
 
       - name: Verify pinned Deno build metadata
         run: bin/zopepy -m pytest src/zopyx/surveyjs/data_validation/tests/test_deno_build.py src/zopyx/surveyjs/data_validation/tests/test_validate_data.py -v

--- a/DISKCACHE.md
+++ b/DISKCACHE.md
@@ -1,0 +1,231 @@
+# DISKCACHE in zopyx.surveyjs — Role & Usage
+
+In-depth outline of every diskcache usage site in this add-on, based on the
+actual code (`monitoring.py`, `browser/services/auth.py`,
+`browser/embed_security.py`, `interfaces.py`, `browser/views.py`) and the
+verified inventory in the `plone-zeo-sqlite-concurrency` skill
+(`references/zopyx-diskcache-inventory.md`).
+
+## Overview
+
+diskcache (`setup.py:73`, runtime dependency; also in test extras at
+`setup.py:92`) is a SQLite-backed key-value cache library. The add-on uses
+it as **three independent cache stores** — there is no central cache
+module; each usage site opens/uses/closes its own `diskcache.Cache`
+instance. Every store is a SQLite database (`cache.db` plus `-wal`/`-shm`
+sidecars), so all three inherit SQLite's concurrency characteristics (one
+writer at a time, WAL journaling, busy_timeout, "not for network
+filesystems").
+
+| # | Store               | Module                       | Character |
+|---|---------------------|------------------------------|-----------|
+| 1 | Auth/token cache    | `browser/services/auth.py`   | security-critical |
+| 2 | Embed token cache   | `browser/embed_security.py`  | security-critical |
+| 3 | Monitoring store    | `monitoring.py`              | analytics / rate limit |
+
+## 1) Auth / token cache (`browser/services/auth.py`)
+
+**Purpose.** Three security functions: authenticity-token replay
+protection, issued-token bookkeeping, and cached "trusted access" token
+state.
+
+**Path** (`interfaces.py:435-440`, `auth.py:83-86`): registry setting
+`authenticity_token_cache_path`, default `"var/token_cache.db"` — a
+**cwd-relative default** (weakness, see "Known weaknesses" below). Read
+via `AuthService._auth_token_cache_path()`.
+
+**Lifecycle pattern.** Every operation opens a fresh `Cache(path)` and
+closes it in a `finally`-block (`_token_cache()` at `auth.py:88-95`). A
+failed open returns `None`; callers then decide fail-closed or fail-open.
+
+**Key namespaces + TTLs**
+
+- `issued:<token>` (`auth.py:111-113, 141`) — value `"ISSUED"`, TTL 24 h.
+  Written when an authenticity token is generated (`build_auth_token`).
+  Bookkeeping only — nothing validates against it.
+- `received:<token>` (`auth.py:115-117, 398-408`) — value `"RECEIVED"`,
+  TTL 24 h. Written with `cache.add()` — the **atomic replay-protection
+  marker**. `add()` returns `True` only if the key did not already exist; a
+  `False` return means the exact same token was submitted before → HTTP
+  403 `auth_token_replay` (`auth.py:400-408`).
+- `trusted:<token>` (`auth.py:44-46, 162-169`) — value = metadata dict,
+  TTL = per-form `trusted_access_ttl_hours` (default 168 h,
+  `auth.py:48-55`). Metadata: `form_id`, `form_version`, `issued_at`,
+  `expires_at`, `state`. Used by `trusted` (cached) access mode only.
+  Revocation is modeled by rewriting `state` to `"REVOKED"` — checked at
+  `auth.py:198-206`.
+
+**Operations used**
+
+- `cache.set(key, value, expire=...)` → issuance + trusted metadata
+- `cache.add(key, value, expire=...)` → atomic replay markers
+- `cache.get(key)` → trusted metadata lookup
+
+The deliberately distinct primitives matter: `set()` for
+"write/overwrite", `add()` for "insert only if absent" — `add()` is the
+replay-protection primitive and is atomic across processes (diskcache's
+own file locking).
+
+**Fail-closed behavior**
+
+- `require_auth_token` (`auth.py:386-396`): cache unavailable → HTTP 503
+  `auth_service_unavailable`, request **rejected** (replay protection must
+  not silently degrade).
+- `_require_trusted_access_cached` (`auth.py:172-184`): cache unavailable
+  → HTTP 503 `trusted_access_cache_unavailable`.
+
+**Role in request flow.** Called from `browser/views.py`:
+`get_form_json` (`views.py:505-506` `_require_trusted_access`) and
+`save_poll` (`views.py:766-769` trusted access + auth token).
+Editors/Managers bypass; direct-DOM embed submissions use the embed token
+stack instead (`views.py:673-764`).
+
+## 2) Embed token cache (`browser/embed_security.py`)
+
+**Purpose.** Direct DOM Embedding: token metadata for tracking/revocation
+plus one-time-use enforcement (anti-replay for embed JWTs).
+
+**Path** (`embed_security.py:53-59`): hardcoded
+`os.path.join(os.getcwd(), "var", "embed_token_cache.db")` — **no registry
+override** (weakness). `_get_embed_cache()` returns `None` on any
+exception.
+
+**Key namespaces + TTLs**
+
+- `embed_token:<jti>` (`embed_security.py:247-258`) — value = metadata
+  dict `{survey_uid, origin, issued_at, expires_at, used: False}`, TTL =
+  token TTL + 60 s (tokens live 60-3600 s; `generate_embed_token` clamps
+  at line 228). Written on token issuance; informational / revocation
+  tracking.
+- `embed_token_used:<jti>` (`embed_security.py:328-330`) — value `True`,
+  TTL 1 h. One-time marker written with `cache.add()` in
+  `mark_token_used()`. `add()` semantics again: `True` = first use
+  (allowed), `False` = replay.
+
+**Fail-closed behavior.** `mark_token_used`
+(`embed_security.py:313-333`): cache unavailable → returns `False` →
+`views.py:840-845` rejects the submission ("fail-closed: deny rather than
+allow replay").
+
+**Role in request flow** (`views.py` `save_poll`, lines 673-764, 840-845):
+embedded clients send `X-Embed-Token`; the view validates origin allowlist
++ JWT signature (`validate_embed_token`), and **after the full submission
+pipeline succeeds** marks the `jti` used via `mark_token_used(jti)`. The
+one-time mark is the last gate before the response is accepted.
+
+## 3) Monitoring store (`monitoring.py`)
+
+**Purpose.** Submission statistics (dashboard time series), per-form
+breakdowns, processing-time latency buckets, and rate limiting. Pure
+analytics plus an optional rate-limit gate.
+
+**Path** (`monitoring.py:46-64`): `$INSTANCE_HOME/var/surveyjs-monitor`,
+else `/tmp/surveyjs-monitor-<site_id>` (`site.getId()`), final fallback
+`/tmp/surveyjs-monitor`. Opened with `Cache(cache_dir, timeout=5)`
+(`monitoring.py:73`) — `timeout` here is diskcache's **lock** timeout, not
+the SQLite busy timeout.
+
+**Key namespaces** (`monitoring.py:27-31`) **+ TTL**
+
+- `sub:<YYYYMMDDHHMM>` — global per-minute submission buckets
+- `form:<uid>:<YYYYMMDDHHMM>` — per-form per-minute buckets
+- `duration:<YYYYMMDDHHMM>` — global per-minute latency buckets
+- `form-duration:<uid>:<...>` — per-form latency buckets
+- `global:stats` — defined, reserved
+
+All entries expire after 25 h (`monitoring.py:186, 260`) so every time
+window (5 m…24 h) is fully covered.
+
+**Operations used**
+
+- read-modify-write counters: `cache.get(key, {})` → mutate dict →
+  `cache.set(key, data, expire=25h)` (`_increment_counter` lines 146-189,
+  `_record_duration_bucket` lines 227-262). **NOT ATOMIC** — get/modify/set
+  loses updates under concurrent clients (known weakness; classified as
+  "may be in-memory").
+- `cache.iterkeys()` full scans for aggregation: `get_submission_stats`
+  (lines 442, 486, 552, 592), `_get_form_time_series` (line 350),
+  `_get_form_breakdown` (line 552), `cleanup_old_data` (line 723). The
+  dashboard reads are O(keys) scans, not indexed queries.
+- `cache.delete(key)` in `cleanup_old_data` (line 739).
+
+**Fail-open behavior.** Monitoring **never** breaks submissions:
+`record_submission` (lines 98-100) and `record_submission_duration`
+(line 199) silently return when the cache is unavailable;
+`_increment_counter` catches everything (lines 188-189);
+`check_rate_limit` returns `(True, {"error": ...})` — i.e. rate limiting
+**fails open** (lines 662-663): it degrades to allowing everything when
+the cache is missing.
+
+**Role in request flow.** `record_submission` runs as an event subscriber
+on the submission event; `record_submission_duration` is called from
+`save_poll` right after the event fires (`views.py:888-890`).
+`check_rate_limit` is the hook for the rate-limiting concept
+(`docs/todo.rst`; not yet wired as a hard gate).
+
+## Cross-cutting: what diskcache gives the app
+
+- **Persistent TTL storage without Redis**: expiry is enforced lazily by
+  diskcache; values are pickled Python dicts.
+- **Atomic `add()`** = the anti-replay primitive used in BOTH security
+  stores (`received:`, `embed_token_used:`). This is the single most
+  important API choice in the codebase.
+- **Multi-process safety on one host**: diskcache's file locking makes
+  `add()` atomic across Zope clients sharing the same cache file.
+- **SQLite defaults**: diskcache 5.x sets `journal_mode=WAL` by default
+  and relies on the DBAPI busy_timeout (5000 ms) — so WAL is correctly in
+  force for all three stores without explicit PRAGMA code.
+
+## Known weaknesses / concurrency semantics (verified, ZEO-relevant)
+
+1. **cwd-dependent paths break replay protection on one host**: the auth
+   default (`"var/token_cache.db"`) and the hardcoded embed path
+   (`os.getcwd()/var/embed_token_cache.db`) resolve per-process when Zope
+   clients start from different directories → silently different cache
+   files → replay markers no longer shared. Only the monitoring store
+   anchors to `INSTANCE_HOME`. (GitHub issue #33, `docs/todo.rst`.)
+2. **Non-atomic counters**: monitoring increments are get/modify/set →
+   lost updates under concurrent clients. Use `Cache.incr` if counts must
+   be exact.
+3. **Multi-server (dedicated ZEO servers / multiple hosts)**: per-server
+   stores mean replay markers, trusted-token revocation/expiry and embed
+   one-time markers become **per-server** → guarantees weaken between
+   servers. Fail-closed 503s do NOT catch this (they only fire when the
+   cache is MISSING, not when it diverges). NFS sharing is not an option
+   (SQLite over NFS unsupported).
+4. **Cluster-safe alternative already in-repo**: `trusted-tokens` mode
+   uses `ITokenStore` (ZODB or SQL backend) — transactional, shared; the
+   pattern for security-critical state.
+
+## Security classification (durable+shared vs in-memory)
+
+**MUST stay durable + shared** (disk or Redis, never process-local
+memory):
+
+- `received:` replay markers
+- `trusted:` trusted-access state (revocation/expiry)
+- `embed_token_used:` one-time markers
+
+**MAY be in-memory** without safety loss:
+
+- monitoring counters/buckets/stats (analytics; disk only buys dashboard
+  history across restarts)
+- `issued:` markers, `embed_token:` metadata (informational)
+
+## Tests & docs
+
+- `tests/test_integration_views.py` references diskcache (replay/trusted
+  access integration coverage).
+- Docs: `docs/security.rst`, `docs/survey-options.rst` (trusted TTL
+  field), `docs/global-options.rst`, `docs/todo.rst` ("Diskcache handling
+  in ZEO deployments" — status open; "Rate limiting concept" uses the same
+  counters). Older analysis docs under `docs/old/` also reference it.
+- Dependency declared in `setup.py` `install_requires` and test extras.
+
+## Bottom line
+
+diskcache is load-bearing for **security** (replay protection and
+one-time-use via atomic `add()`, fail-closed) and for **analytics**
+(monitoring counters, fail-open). Its main risk surface in production is
+path resolution (cwd dependence) and per-server divergence in multi-server
+ZEO setups — both tracked in issue #33 / `docs/todo.rst`.

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -42,3 +42,71 @@ The package currently ships monitoring only, not enforcement:
    the request path, not only after acceptance).
 #. Documented behavior for embed and direct-DOM submission paths, which
    bypass trusted-access token checks.
+
+Diskcache handling in ZEO deployments
+-------------------------------------
+
+**Status:** open
+
+All three diskcache stores (SQLite files) are written and read by every
+Zope client process, so their behavior in a ZEO setup — multiple local
+clients on one host, or dedicated servers — needs an explicit design.
+Current state (verified by inspection and an engine probe):
+
+* Three usage sites, all SQLite-on-local-disk via diskcache:
+
+  * Monitoring counters (``monitoring.py``): per-minute submission
+    counters, latency buckets and global stats with 25 h expiry, under
+    ``$INSTANCE_HOME/var/surveyjs-monitor`` (``/tmp`` fallback). Pure
+    analytics — submissions are durably stored in ZODB/SQL regardless.
+  * Auth/token cache (``browser/services/auth.py``): ``issued:``
+    markers, ``received:`` auth-token replay markers (24 h) and
+    ``trusted:`` trusted-access token metadata (TTL hours), under the
+    registry setting ``authenticity_token_cache_path`` with a
+    **cwd-relative** default (``var/token_cache.db``).
+  * Embed cache (``browser/embed_security.py``): ``embed_token:``
+    metadata and ``embed_token_used:`` one-time markers (1 h), under
+    ``os.getcwd()/var/embed_token_cache.db`` — hardcoded, no registry
+    override, cwd-dependent.
+
+* Diskcache itself is multi-process safe on one host (WAL mode verified,
+  atomic ``add`` for one-time markers, fail-closed when the cache is
+  unavailable). SQLite over network filesystems (NFS, SMB) is
+  explicitly ruled out by ``docs/storage.rst`` and applies to diskcache
+  identically.
+* Known weaknesses in a ZEO setup:
+
+  * Two of the three paths depend on the process working directory;
+    clients started from different directories silently use different
+    cache files, which breaks replay protection even on a single host.
+  * Monitoring counter increments are non-atomic get/modify/set
+    (``monitoring.py``) — concurrent clients lose updates.
+  * Multi-server: per-server stores weaken security state — auth-token
+    replay markers, trusted-token revocation/expiry and embed one-time
+    markers are then per-server, while ``trusted-tokens`` mode (ITokenStore
+    in ZODB/SQL) stays cluster-safe. The monitor dashboard shows only
+    local traffic.
+
+**Task:** design the diskcache handling concept covering at least:
+
+#. Unify cache path configuration: registry settings for the embed and
+   monitoring caches (auth already has one) and resolve all relative
+   paths against ``INSTANCE_HOME``, never against the working directory.
+#. Per-deployment topology matrix (single process / multiple local ZEO
+   clients / dedicated servers with or without a shared filesystem) and
+   which guarantees hold in each: replay protection, trusted-token
+   revocation and expiry, embed one-time use, monitoring completeness,
+   fail-closed behavior.
+#. Storage policy for security-critical state (``received:`` replay
+   markers, ``trusted:`` token state, ``embed_token_used:`` markers):
+   keep durable diskcache on one host, or move to the transactional
+   store (ZODB/SQL, the ITokenStore pattern) / a shared in-memory store
+   (e.g. Redis) for cluster-correct semantics.
+#. Which entries may move to in-memory without safety loss: monitoring
+   counters and buckets, ``issued:`` markers, ``embed_token:`` metadata
+   — and whether a shared store should replace all three sites.
+#. Atomic monitoring increments (``Cache.incr`` / check-and-consume) and
+   an explicit decision on cross-server aggregation for the dashboard
+   and any future rate limiting.
+#. Tests pinning cache-path resolution (INSTANCE_HOME vs. cwd) and
+   concurrent counter/one-time-marker behavior.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,24 @@
+[tool.uv]
+# uv-only configuration: this is a buildout project. uv only bootstraps
+# the buildout toolchain (equivalent to `uv venv` + `uv pip install -r
+# requirements.txt`). Do NOT add a [project] table here: setuptools would
+# switch to PEP 621 hybrid mode and break the buildout develop step
+# (`pip install -e .` crashes on setup.py's string entry_points, and
+# [project].dependencies would override setup.py's install_requires).
+package = false
+
+[dependency-groups]
+dev = [
+    "packaging==26.3",
+    "horse-with-no-namespace==20260202.0",
+    "pip==26.1.2",
+    "setuptools==81.0.0",
+    "wheel==0.47.0",
+    "zc.buildout==5.2.0",
+    "pywin32; platform_system == 'Windows'",
+    "certifi; platform_system == 'Windows'",
+]
+
 [tool.ruff]
 exclude = ["scripts", "fillable_forms"]
 

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,12 @@ setup(
             "orjson",
             "diskcache",
             "polib",
+            # KV facade portability suite (test-only engines)
+            "duckdb",
+            "duckdb-engine",
+            "testcontainers",
+            "psycopg2-binary",
+            "pymysql",
         ],
     },
     entry_points="""

--- a/src/zopyx/surveyjs/kv.py
+++ b/src/zopyx/surveyjs/kv.py
@@ -1,15 +1,17 @@
 # -*- coding: utf-8 -*-
 """Key-value store facade mirroring the diskcache API used by zopyx.surveyjs.
 
-Two interchangeable implementations of the six-method :class:`KVStore`
-interface:
+Two families of interchangeable implementations of the six-method
+:class:`KVStore` interface:
 
 * :class:`DiskCacheStore` — a thin pass-through wrapper over
   ``diskcache.Cache`` preserving its behavior (including an explicit zero
   lock timeout).
-* :class:`SQLKVStore` — a SQLite-only backend backed by a single
-  ``survey_kv_store`` table, using SQLite dialect upsert statements with
-  atomic ``add()`` semantics and epoch-based expiry.
+* :class:`SQLKVStore` — an SQLAlchemy-backed store on a single
+  ``survey_kv_store`` table, supporting the SQLite, DuckDB, PostgreSQL and
+  MySQL dialects. Expiry is stored as a UTC epoch float (no
+  timezone-aware/naive datetime comparisons) and writes use atomic
+  single-statement DML (see "Write semantics" below).
 
 The production call sites (``browser/services/auth.py``,
 ``browser/embed_security.py``, ``monitoring.py``) are unchanged in this
@@ -18,6 +20,19 @@ phase; this module only provides the facade they will later be wired to.
 Supported API methods: ``set``, ``add``, ``get``, ``iterkeys``, ``delete``,
 ``close`` — with TTL via the ``expire`` parameter (seconds; ``None`` means
 no expiry).
+
+Write semantics
+---------------
+``set()`` is INSERT with a fallback UPDATE on the unique-key conflict —
+never a read-then-write sequence, so concurrent writers cannot lose the
+value. ``add()`` is the security-sensitive primitive: it returns ``True``
+exactly once for concurrent attempts on an absent or expired key. It runs
+the INSERT first; on the unique-key conflict it performs a conditional
+UPDATE that only matches an expired row (``expires_at IS NOT NULL AND
+expires_at <= now``). The success signal is dialect-appropriate: the
+UPDATE...RETURNING row presence for SQLite/DuckDB/PostgreSQL (MySQL has no
+RETURNING; rowcount is used there). A live existing row fails the WHERE
+clause, so ``add()`` returns False for it.
 
 Deliberate deviations from raw diskcache (pinned by tests):
 
@@ -42,15 +57,18 @@ from typing import Any, Iterator, Optional
 
 import diskcache
 import orjson
-from sqlalchemy import Column, Float, String, Text, and_, delete, or_, select
-from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy import Column, Double, String, Text, and_, delete, insert, or_, select, update
+from sqlalchemy.dialects.mysql import LONGTEXT
 from sqlalchemy.engine import make_url
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlmodel import Field, SQLModel
 
 from .storage import _get_engine
 
 MAX_KEY_LENGTH = 255
+
+#: SQL dialects SQLKVStore is implemented and tested against.
+SUPPORTED_BACKENDS = frozenset({"sqlite", "duckdb", "postgresql", "mysql"})
 
 _LOCKED_ERROR_FRAGMENTS = ("database is locked", "database is busy")
 
@@ -126,10 +144,14 @@ class KVEntry(SQLModel, table=True):
     key: str = Field(
         sa_column=Column(String(MAX_KEY_LENGTH), primary_key=True, nullable=False)
     )
-    value: str = Field(sa_column=Column(Text, nullable=False))
-    # UTC epoch seconds; NULL means "no expiry".
+    value: str = Field(
+        sa_column=Column(Text().with_variant(LONGTEXT(), "mysql"), nullable=False)
+    )
+    # UTC epoch seconds; NULL means "no expiry". Double (64-bit) on every
+    # dialect: Float would compile to 32-bit FLOAT on DuckDB/MySQL and lose
+    # epoch precision.
     expires_at: Optional[float] = Field(
-        default=None, sa_column=Column(Float, nullable=True)
+        default=None, sa_column=Column(Double, nullable=True)
     )
 
 
@@ -189,21 +211,26 @@ def _retry_locked(operation, attempts: int = 5, base_delay: float = 0.02):
 
 
 class SQLKVStore(KVStore):
-    """SQLite-backed KV store with atomic write semantics.
+    """SQLAlchemy-backed KV store with atomic write semantics.
 
-    Supported URI scheme: ``sqlite`` only. Expiry is stored as a UTC epoch
+    Supported URI schemes: ``sqlite``, ``duckdb``, ``postgresql``, ``mysql``
+    (anything else raises ``ValueError``). Expiry is stored as a UTC epoch
     float, avoiding timezone-aware/naive datetime differences between
-    SQLite and SQLAlchemy.
+    dialects.
     """
 
     def __init__(self, database_uri: str):
         url = make_url(database_uri)
-        if url.get_backend_name() != "sqlite":
+        backend = url.get_backend_name()
+        if backend not in SUPPORTED_BACKENDS:
             raise ValueError(
-                "SQLKVStore supports SQLite URIs only, got backend "
-                f"{url.get_backend_name()!r}"
+                f"SQLKVStore supports {sorted(SUPPORTED_BACKENDS)} URIs, "
+                f"got backend {backend!r}"
             )
         self._uri = database_uri
+        self._backend = backend
+        # MySQL has no UPDATE ... RETURNING; rowcount is the success signal.
+        self._uses_rowcount = backend == "mysql"
         self._engine = _get_engine(database_uri)
         # Explicit create_all: the engine may already be cached from an
         # earlier construction (e.g. by SQLResultStorage) before this table
@@ -222,27 +249,35 @@ class SQLKVStore(KVStore):
         deadline = _deadline(expire)
 
         def _op():
-            stmt = sqlite_insert(KVEntry).values(
-                key=key, value=encoded, expires_at=deadline
-            )
-            stmt = stmt.on_conflict_do_update(
-                index_elements=[KVEntry.key],
-                set_={"value": encoded, "expires_at": deadline},
-            )
             with self._session() as session:
-                session.execute(stmt)
-                session.commit()
+                try:
+                    session.execute(
+                        insert(KVEntry).values(
+                            key=key, value=encoded, expires_at=deadline
+                        )
+                    )
+                    session.commit()
+                except IntegrityError:
+                    # Key exists (possibly with a value refreshed by a
+                    # concurrent writer): overwrite unconditionally.
+                    session.rollback()
+                    session.execute(
+                        update(KVEntry)
+                        .where(KVEntry.key == key)
+                        .values(value=encoded, expires_at=deadline)
+                    )
+                    session.commit()
             return True
 
         return _retry_locked(_op)
 
     def add(self, key: str, value: Any, expire: Optional[float] = None) -> bool:
-        """Insert only if absent or expired; atomic via a single statement.
+        """Insert only if absent or expired; atomic test-and-set.
 
-        ``INSERT ... ON CONFLICT(key) DO UPDATE ... WHERE expires_at <= now``
-        returns a row only when the insert succeeded or an expired row was
-        replaced. A live existing row fails the WHERE clause, so no row is
-        returned and the caller sees False.
+        The INSERT succeeds exactly once for concurrent callers. A unique
+        conflict is resolved by a conditional UPDATE that only matches an
+        expired row (``expires_at <= now``); a live row leaves the value
+        untouched and reports False.
         """
         key = _validate_key(key)
         encoded = _encode(value)
@@ -250,20 +285,36 @@ class SQLKVStore(KVStore):
         now = time.time()
 
         def _op():
-            stmt = sqlite_insert(KVEntry).values(
-                key=key, value=encoded, expires_at=deadline
-            )
-            stmt = stmt.on_conflict_do_update(
-                index_elements=[KVEntry.key],
-                set_={"value": encoded, "expires_at": deadline},
-                where=and_(
-                    KVEntry.expires_at.isnot(None), KVEntry.expires_at <= now
-                ),
-            ).returning(KVEntry.key)
             with self._session() as session:
-                row = session.execute(stmt).first()
-                session.commit()
-            return row is not None
+                try:
+                    session.execute(
+                        insert(KVEntry).values(
+                            key=key, value=encoded, expires_at=deadline
+                        )
+                    )
+                    session.commit()
+                    return True
+                except IntegrityError:
+                    session.rollback()
+                    conflict_stmt = (
+                        update(KVEntry)
+                        .where(
+                            KVEntry.key == key,
+                            KVEntry.expires_at.isnot(None),
+                            KVEntry.expires_at <= now,
+                        )
+                        .values(value=encoded, expires_at=deadline)
+                    )
+                    if self._uses_rowcount:
+                        result = session.execute(conflict_stmt)
+                        replaced = result.rowcount == 1
+                    else:
+                        result = session.execute(
+                            conflict_stmt.returning(KVEntry.key)
+                        )
+                        replaced = result.first() is not None
+                    session.commit()
+                    return replaced
 
         return _retry_locked(_op)
 
@@ -307,7 +358,8 @@ class SQLKVStore(KVStore):
             with self._session() as session:
                 result = session.execute(delete(KVEntry).where(KVEntry.key == key))
                 session.commit()
-                return result.rowcount > 0
+                # DuckDB reports -1; the return value is informational.
+                return result.rowcount > 0 if result.rowcount is not None else False
 
         return _retry_locked(_op)
 
@@ -320,8 +372,9 @@ def get_kv_store(
 ) -> KVStore:
     """Construct a KV store implementation.
 
-    :param backend: exactly ``diskcache`` or ``sqlite``.
-    :param path_or_uri: filesystem path (diskcache) or SQLAlchemy SQLite URI.
+    :param backend: one of ``diskcache``, ``sqlite``, ``duckdb``,
+        ``postgresql``, ``mysql``.
+    :param path_or_uri: filesystem path (diskcache) or SQLAlchemy URI.
         Required — there is no implicit cwd-relative default.
     :param timeout: diskcache lock timeout (diskcache backend only).
     """
@@ -330,8 +383,9 @@ def get_kv_store(
     backend_name = (backend or "").strip().lower()
     if backend_name == "diskcache":
         return DiskCacheStore(path_or_uri, timeout=timeout)
-    if backend_name == "sqlite":
+    if backend_name in SUPPORTED_BACKENDS:
         return SQLKVStore(path_or_uri)
     raise ValueError(
-        f"unknown backend {backend_name!r}; expected 'diskcache' or 'sqlite'"
+        f"unknown backend {backend_name!r}; expected one of "
+        f"'diskcache', {sorted(SUPPORTED_BACKENDS)}"
     )

--- a/src/zopyx/surveyjs/kv.py
+++ b/src/zopyx/surveyjs/kv.py
@@ -1,0 +1,337 @@
+# -*- coding: utf-8 -*-
+"""Key-value store facade mirroring the diskcache API used by zopyx.surveyjs.
+
+Two interchangeable implementations of the six-method :class:`KVStore`
+interface:
+
+* :class:`DiskCacheStore` — a thin pass-through wrapper over
+  ``diskcache.Cache`` preserving its behavior (including an explicit zero
+  lock timeout).
+* :class:`SQLKVStore` — a SQLite-only backend backed by a single
+  ``survey_kv_store`` table, using SQLite dialect upsert statements with
+  atomic ``add()`` semantics and epoch-based expiry.
+
+The production call sites (``browser/services/auth.py``,
+``browser/embed_security.py``, ``monitoring.py``) are unchanged in this
+phase; this module only provides the facade they will later be wired to.
+
+Supported API methods: ``set``, ``add``, ``get``, ``iterkeys``, ``delete``,
+``close`` — with TTL via the ``expire`` parameter (seconds; ``None`` means
+no expiry).
+
+Deliberate deviations from raw diskcache (pinned by tests):
+
+1. SQL values are JSON encoded with orjson, not pickled; only
+   JSON-compatible values are supported (``TypeError`` for anything else).
+2. SQL ``iterkeys()`` excludes already-expired rows; the diskcache wrapper
+   preserves diskcache's own (culling-dependent) behavior.
+3. SQL ``get()`` may delete an expired row it encounters (conditional lazy
+   purge); diskcache owns its own culling behavior.
+4. SQL keys longer than 255 Unicode code points raise ``ValueError`` from
+   every method; diskcache accepts arbitrary string keys.
+5. ``SQLKVStore.close()`` is a no-op because sessions are operation-scoped
+   and the engine is shared/cached. A closed ``DiskCacheStore`` preserves
+   diskcache's post-close behavior.
+"""
+
+from __future__ import annotations
+
+import abc
+import time
+from typing import Any, Iterator, Optional
+
+import diskcache
+import orjson
+from sqlalchemy import Column, Float, String, Text, and_, delete, or_, select
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.engine import make_url
+from sqlalchemy.exc import OperationalError
+from sqlmodel import Field, SQLModel
+
+from .storage import _get_engine
+
+MAX_KEY_LENGTH = 255
+
+_LOCKED_ERROR_FRAGMENTS = ("database is locked", "database is busy")
+
+
+class KVStore(abc.ABC):
+    """Interface mirroring the diskcache calls used in this codebase."""
+
+    @abc.abstractmethod
+    def set(self, key: str, value: Any, expire: Optional[float] = None) -> Any:
+        """Store ``value`` under ``key``, expiring after ``expire`` seconds
+        (``None`` = no expiry). Returns a truthy result on success."""
+
+    @abc.abstractmethod
+    def add(self, key: str, value: Any, expire: Optional[float] = None) -> bool:
+        """Store only if ``key`` is absent or expired; return True exactly
+        once for concurrent attempts on the same key."""
+
+    @abc.abstractmethod
+    def get(self, key: str, default: Any = None) -> Any:
+        """Return the value for ``key``, or ``default`` when missing or
+        expired."""
+
+    @abc.abstractmethod
+    def iterkeys(self) -> Iterator[str]:
+        """Yield the live (non-expired) keys."""
+
+    @abc.abstractmethod
+    def delete(self, key: str) -> Any:
+        """Remove ``key`` if present; return a truthy result when a key was
+        removed."""
+
+    @abc.abstractmethod
+    def close(self) -> None:
+        """Release resources."""
+
+
+class DiskCacheStore(KVStore):
+    """Pass-through facade over ``diskcache.Cache`` (identical behavior)."""
+
+    def __init__(self, path: str, timeout: Optional[float] = None):
+        if timeout is not None:
+            # Preserve an explicit zero instead of falling back to
+            # diskcache's default lock timeout.
+            self._cache = diskcache.Cache(path, timeout=timeout)
+        else:
+            self._cache = diskcache.Cache(path)
+
+    def set(self, key: str, value: Any, expire: Optional[float] = None) -> Any:
+        return self._cache.set(key, value, expire=expire)
+
+    def add(self, key: str, value: Any, expire: Optional[float] = None) -> bool:
+        return bool(self._cache.add(key, value, expire=expire))
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._cache.get(key, default=default)
+
+    def iterkeys(self) -> Iterator[str]:
+        return iter(self._cache.iterkeys())
+
+    def delete(self, key: str) -> Any:
+        return self._cache.delete(key)
+
+    def close(self) -> None:
+        self._cache.close()
+
+
+class KVEntry(SQLModel, table=True):
+    """SQL table backing :class:`SQLKVStore` (one row per key)."""
+
+    __tablename__ = "survey_kv_store"
+    __table_args__ = {"extend_existing": True}
+
+    key: str = Field(
+        sa_column=Column(String(MAX_KEY_LENGTH), primary_key=True, nullable=False)
+    )
+    value: str = Field(sa_column=Column(Text, nullable=False))
+    # UTC epoch seconds; NULL means "no expiry".
+    expires_at: Optional[float] = Field(
+        default=None, sa_column=Column(Float, nullable=True)
+    )
+
+
+def _validate_key(key: Any) -> str:
+    """Validate a key against the facade contract.
+
+    SQLite does not enforce VARCHAR length, so the limit is enforced here.
+    """
+    if not isinstance(key, str):
+        raise TypeError(f"key must be str, got {type(key).__name__}")
+    if len(key) > MAX_KEY_LENGTH:
+        raise ValueError(
+            f"key longer than {MAX_KEY_LENGTH} characters: {len(key)}"
+        )
+    return key
+
+
+def _encode(value: Any) -> str:
+    """JSON-encode a value; unsupported values raise TypeError."""
+    return orjson.dumps(value).decode("utf-8")
+
+
+def _decode(raw: str) -> Any:
+    return orjson.loads(raw)
+
+
+def _deadline(expire: Optional[float]) -> Optional[float]:
+    """UTC epoch deadline for ``expire`` seconds from now (None = never)."""
+    if expire is None:
+        return None
+    return time.time() + expire
+
+
+def _is_locked_error(exc: OperationalError) -> bool:
+    message = str(exc).lower()
+    return any(fragment in message for fragment in _LOCKED_ERROR_FRAGMENTS)
+
+
+def _retry_locked(operation, attempts: int = 5, base_delay: float = 0.02):
+    """Run ``operation`` (which opens its own session) retrying transient
+    SQLite lock errors with bounded exponential backoff.
+
+    Each retry reruns the whole statement in a fresh session; the failed
+    session is closed by its context manager. Non-lock operational errors
+    and all other errors propagate immediately.
+    """
+    last_exc = None
+    for attempt in range(attempts):
+        try:
+            return operation()
+        except OperationalError as exc:
+            last_exc = exc
+            if not _is_locked_error(exc):
+                raise
+            time.sleep(base_delay * (2**attempt))
+    raise last_exc
+
+
+class SQLKVStore(KVStore):
+    """SQLite-backed KV store with atomic write semantics.
+
+    Supported URI scheme: ``sqlite`` only. Expiry is stored as a UTC epoch
+    float, avoiding timezone-aware/naive datetime differences between
+    SQLite and SQLAlchemy.
+    """
+
+    def __init__(self, database_uri: str):
+        url = make_url(database_uri)
+        if url.get_backend_name() != "sqlite":
+            raise ValueError(
+                "SQLKVStore supports SQLite URIs only, got backend "
+                f"{url.get_backend_name()!r}"
+            )
+        self._uri = database_uri
+        self._engine = _get_engine(database_uri)
+        # Explicit create_all: the engine may already be cached from an
+        # earlier construction (e.g. by SQLResultStorage) before this table
+        # class was registered, in which case _get_engine will not create it.
+        SQLModel.metadata.create_all(self._engine)
+
+    def _session(self):
+        from sqlmodel import Session
+
+        return Session(self._engine)
+
+    def set(self, key: str, value: Any, expire: Optional[float] = None) -> Any:
+        """Insert or replace unconditionally (atomic upsert)."""
+        key = _validate_key(key)
+        encoded = _encode(value)
+        deadline = _deadline(expire)
+
+        def _op():
+            stmt = sqlite_insert(KVEntry).values(
+                key=key, value=encoded, expires_at=deadline
+            )
+            stmt = stmt.on_conflict_do_update(
+                index_elements=[KVEntry.key],
+                set_={"value": encoded, "expires_at": deadline},
+            )
+            with self._session() as session:
+                session.execute(stmt)
+                session.commit()
+            return True
+
+        return _retry_locked(_op)
+
+    def add(self, key: str, value: Any, expire: Optional[float] = None) -> bool:
+        """Insert only if absent or expired; atomic via a single statement.
+
+        ``INSERT ... ON CONFLICT(key) DO UPDATE ... WHERE expires_at <= now``
+        returns a row only when the insert succeeded or an expired row was
+        replaced. A live existing row fails the WHERE clause, so no row is
+        returned and the caller sees False.
+        """
+        key = _validate_key(key)
+        encoded = _encode(value)
+        deadline = _deadline(expire)
+        now = time.time()
+
+        def _op():
+            stmt = sqlite_insert(KVEntry).values(
+                key=key, value=encoded, expires_at=deadline
+            )
+            stmt = stmt.on_conflict_do_update(
+                index_elements=[KVEntry.key],
+                set_={"value": encoded, "expires_at": deadline},
+                where=and_(
+                    KVEntry.expires_at.isnot(None), KVEntry.expires_at <= now
+                ),
+            ).returning(KVEntry.key)
+            with self._session() as session:
+                row = session.execute(stmt).first()
+                session.commit()
+            return row is not None
+
+        return _retry_locked(_op)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        key = _validate_key(key)
+        now = time.time()
+        with self._session() as session:
+            row = session.get(KVEntry, key)
+            if row is None:
+                return default
+            if row.expires_at is not None and row.expires_at <= now:
+                # Conditional lazy purge: never delete a row that a
+                # concurrent writer refreshed after our observed `now`.
+                session.execute(
+                    delete(KVEntry).where(
+                        KVEntry.key == key, KVEntry.expires_at <= now
+                    )
+                )
+                session.commit()
+                return default
+            try:
+                return _decode(row.value)
+            except orjson.JSONDecodeError:
+                return default
+
+    def iterkeys(self) -> Iterator[str]:
+        now = time.time()
+        with self._session() as session:
+            stmt = select(KVEntry.key).where(
+                or_(KVEntry.expires_at.is_(None), KVEntry.expires_at > now)
+            )
+            # Materialize while the session is open; do not hand out a
+            # session-backed generator.
+            keys = list(session.execute(stmt).scalars())
+        return iter(keys)
+
+    def delete(self, key: str) -> Any:
+        key = _validate_key(key)
+
+        def _op():
+            with self._session() as session:
+                result = session.execute(delete(KVEntry).where(KVEntry.key == key))
+                session.commit()
+                return result.rowcount > 0
+
+        return _retry_locked(_op)
+
+    def close(self) -> None:
+        """No-op: sessions are operation-scoped and the engine is shared."""
+
+
+def get_kv_store(
+    backend: str, path_or_uri: str, timeout: Optional[float] = None
+) -> KVStore:
+    """Construct a KV store implementation.
+
+    :param backend: exactly ``diskcache`` or ``sqlite``.
+    :param path_or_uri: filesystem path (diskcache) or SQLAlchemy SQLite URI.
+        Required — there is no implicit cwd-relative default.
+    :param timeout: diskcache lock timeout (diskcache backend only).
+    """
+    if not path_or_uri:
+        raise ValueError("path_or_uri is required")
+    backend_name = (backend or "").strip().lower()
+    if backend_name == "diskcache":
+        return DiskCacheStore(path_or_uri, timeout=timeout)
+    if backend_name == "sqlite":
+        return SQLKVStore(path_or_uri)
+    raise ValueError(
+        f"unknown backend {backend_name!r}; expected 'diskcache' or 'sqlite'"
+    )

--- a/src/zopyx/surveyjs/tests/test_kv.py
+++ b/src/zopyx/surveyjs/tests/test_kv.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 """Contract and deviation tests for the KV store facade.
 
-Runs the same behavioral contract against the diskcache wrapper and the
-SQLite-backed implementation, plus backend-specific deviation tests
-(JSON-only values, key-length limit, expired-key iteration/purge) and
-bounded thread-race coverage.
+Runs the same behavioral contract against the diskcache wrapper and every
+SQL backend (SQLite, DuckDB; PostgreSQL/MySQL live in
+``test_kv_db_containers.py`` and reuse the same mixins), plus
+backend-specific deviation tests (JSON-only values, key-length limit,
+expired-key iteration/purge) and bounded thread-race coverage.
 """
 
 from __future__ import annotations
@@ -16,21 +17,34 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
-from zopyx.surveyjs.kv import DiskCacheStore, SQLKVStore, get_kv_store
+from sqlalchemy import delete
+
+from zopyx.surveyjs.kv import (
+    DiskCacheStore,
+    KVEntry,
+    SQLKVStore,
+    get_kv_store,
+)
 from zopyx.surveyjs.storage import SQLResultStorage
 
 
 class KVStoreContractBase:
-    """Common behavioral contract; concrete backend classes combine this
-    mixin with ``unittest.TestCase`` so the base itself is never collected
-    by the test runner."""
+    """Common behavioral contract shared by every backend.
+
+    Mixin only: concrete backend classes combine it with
+    ``unittest.TestCase`` so the base is never collected by the runner.
+    """
 
     def make_store(self):
         raise NotImplementedError
 
+    def _purge(self):
+        """Reset the store so each test starts from an empty state."""
+
     def setUp(self):
         self.tmpdir = TemporaryDirectory()
         self.store = self.make_store()
+        self._purge()
         self.addCleanup(self._close_store)
 
     def _close_store(self):
@@ -39,7 +53,7 @@ class KVStoreContractBase:
         except Exception:
             pass
         # Dispose the (per-test, cached) engine so the SQLAlchemy pool
-        # releases its sqlite3 handles (no ResourceWarning noise).
+        # releases its handles (no ResourceWarning noise).
         engine = getattr(self.store, "_engine", None)
         if engine is not None:
             try:
@@ -181,20 +195,17 @@ class KVStoreContractBase:
         self.assertEqual(self.store.get("big"), payload)
 
 
-class DiskCacheStoreTests(KVStoreContractBase, unittest.TestCase):
-    """The diskcache wrapper must preserve diskcache behavior."""
+class SQLBackendPurgeMixin:
+    """Reset the SQL table before each test (shared-DB isolation)."""
 
-    def make_store(self):
-        return DiskCacheStore(f"{self.tmpdir.name}/cache.db")
+    def _purge(self):
+        with self.store._session() as session:
+            session.execute(delete(KVEntry))
+            session.commit()
 
 
-class SQLKVStoreTests(KVStoreContractBase, unittest.TestCase):
-    """SQLite-backed store: common contract plus SQL deviations."""
-
-    def make_store(self):
-        return SQLKVStore(f"sqlite:///{self.tmpdir.name}/kv.db")
-
-    # -- SQL-specific edge cases ---------------------------------------
+class SQLContractMixin:
+    """SQL-backend edge cases shared by every SQL dialect."""
 
     def test_key_exactly_255_chars(self):
         key = "k" * 255
@@ -216,9 +227,31 @@ class SQLKVStoreTests(KVStoreContractBase, unittest.TestCase):
         with self.assertRaises(TypeError):
             self.store.set("k1", object())
 
-    def test_rejects_non_sqlite_uri(self):
+    def test_unsupported_uri_backend_rejected(self):
         with self.assertRaises(ValueError):
-            SQLKVStore("postgresql://user:pass@localhost:5432/db")
+            SQLKVStore("mssql://user:pass@localhost/db")
+
+    def test_iterkeys_excludes_expired_rows(self):
+        self.store.set("old", "v", expire=-1)
+        self.store.set("new", "v", expire=60)
+        self.assertEqual(sorted(self.store.iterkeys()), ["new"])
+
+
+class DiskCacheStoreTests(KVStoreContractBase, unittest.TestCase):
+    """The diskcache wrapper must preserve diskcache behavior."""
+
+    def make_store(self):
+        return DiskCacheStore(f"{self.tmpdir.name}/cache.db")
+
+    def _purge(self):
+        self.store._cache.clear()
+
+
+class SQLiteKVStoreTests(
+    SQLBackendPurgeMixin, SQLContractMixin, KVStoreContractBase, unittest.TestCase
+):
+    def make_store(self):
+        return SQLKVStore(f"sqlite:///{self.tmpdir.name}/kv.db")
 
     def test_engine_cached_by_result_storage_is_reused(self):
         """Regression: an engine cached before the KV table existed must
@@ -228,11 +261,17 @@ class SQLKVStoreTests(KVStoreContractBase, unittest.TestCase):
         kv = SQLKVStore(uri)
         kv.set("k1", {"ok": True})
         self.assertEqual(kv.get("k1"), {"ok": True})
+        kv.close()
+        engine = getattr(kv, "_engine", None)
+        if engine is not None:
+            engine.dispose()
 
-    def test_iterkeys_excludes_expired_rows(self):
-        self.store.set("old", "v", expire=-1)
-        self.store.set("new", "v", expire=60)
-        self.assertEqual(sorted(self.store.iterkeys()), ["new"])
+
+class DuckDBKVStoreTests(
+    SQLBackendPurgeMixin, SQLContractMixin, KVStoreContractBase, unittest.TestCase
+):
+    def make_store(self):
+        return SQLKVStore(f"duckdb:///{self.tmpdir.name}/kv.duckdb")
 
 
 class KVStoreConcurrencyBase:
@@ -255,8 +294,6 @@ class KVStoreConcurrencyBase:
             self.store.close()
         except Exception:
             pass
-        # Dispose the (per-test, cached) engine so the SQLAlchemy pool
-        # releases its sqlite3 handles (no ResourceWarning noise).
         engine = getattr(self.store, "_engine", None)
         if engine is not None:
             try:
@@ -338,9 +375,14 @@ class DiskCacheStoreConcurrencyTests(KVStoreConcurrencyBase, unittest.TestCase):
         return DiskCacheStore(f"{self.tmpdir.name}/cache.db")
 
 
-class SQLKVStoreConcurrencyTests(KVStoreConcurrencyBase, unittest.TestCase):
+class SQLiteKVStoreConcurrencyTests(KVStoreConcurrencyBase, unittest.TestCase):
     def make_store(self):
         return SQLKVStore(f"sqlite:///{self.tmpdir.name}/kv.db")
+
+
+class DuckDBKVStoreConcurrencyTests(KVStoreConcurrencyBase, unittest.TestCase):
+    def make_store(self):
+        return SQLKVStore(f"duckdb:///{self.tmpdir.name}/kv.duckdb")
 
 
 class FactoryTests(unittest.TestCase):
@@ -362,6 +404,36 @@ class FactoryTests(unittest.TestCase):
             engine = getattr(store, "_engine", None)
             if engine is not None:
                 engine.dispose()
+
+    def test_duckdb_factory(self):
+        with TemporaryDirectory() as td:
+            store = get_kv_store("duckdb", f"duckdb:///{td}/kv.duckdb")
+            self.assertIsInstance(store, SQLKVStore)
+            store.set("k1", "v1")
+            self.assertEqual(store.get("k1"), "v1")
+            store.close()
+            engine = getattr(store, "_engine", None)
+            if engine is not None:
+                engine.dispose()
+
+    def test_postgresql_factory(self):
+        # Construction must not require a live server.
+        with patch("zopyx.surveyjs.kv._get_engine") as mock_engine, patch(
+            "zopyx.surveyjs.kv.SQLModel.metadata.create_all"
+        ):
+            mock_engine.return_value = object()
+            store = get_kv_store(
+                "postgresql", "postgresql://user:pass@localhost:5432/db"
+            )
+            self.assertIsInstance(store, SQLKVStore)
+
+    def test_mysql_factory(self):
+        with patch("zopyx.surveyjs.kv._get_engine") as mock_engine, patch(
+            "zopyx.surveyjs.kv.SQLModel.metadata.create_all"
+        ):
+            mock_engine.return_value = object()
+            store = get_kv_store("mysql", "mysql+pymysql://user:pass@localhost/db")
+            self.assertIsInstance(store, SQLKVStore)
 
     def test_unknown_backend_raises(self):
         with self.assertRaises(ValueError):

--- a/src/zopyx/surveyjs/tests/test_kv.py
+++ b/src/zopyx/surveyjs/tests/test_kv.py
@@ -10,6 +10,8 @@ expired-key iteration/purge) and bounded thread-race coverage.
 
 from __future__ import annotations
 
+import os
+import subprocess
 import threading
 import time
 import unittest
@@ -194,6 +196,56 @@ class KVStoreContractBase:
         self.store.set("big", payload)
         self.assertEqual(self.store.get("big"), payload)
 
+    # -- edge keys / values --------------------------------------------
+
+    def test_empty_string_key(self):
+        self.store.set("", "v")
+        self.assertEqual(self.store.get(""), "v")
+        self.store.delete("")
+        self.assertIsNone(self.store.get(""))
+
+    def test_float_precision_fidelity(self):
+        value = 0.1 + 0.2
+        self.store.set("f", value)
+        self.assertEqual(self.store.get("f"), value)
+
+    # -- lifecycle ------------------------------------------------------
+
+    def make_second_store(self):
+        """Return a NEW store on the same location as the current one."""
+        raise NotImplementedError
+
+    def test_persistence_across_reopen(self):
+        self.store.set("k1", "v1")
+        self.store.set("k2", {"nested": [1, True, None]})
+        self.store.set("ttl", "soon", expire=60)
+        self.store.close()
+        store2 = self.make_second_store()
+        self.store = store2
+        self.assertEqual(store2.get("k1"), "v1")
+        self.assertEqual(store2.get("k2"), {"nested": [1, True, None]})
+        self.assertEqual(store2.get("ttl"), "soon")
+
+    def test_expired_value_gone_after_reopen(self):
+        self.store.set("gone", "x", expire=-1)
+        self.store.set("live", "y", expire=60)
+        self.store.close()
+        store2 = self.make_second_store()
+        self.store = store2
+        self.assertIsNone(store2.get("gone"))
+        self.assertEqual(store2.get("live"), "y")
+
+    def test_ops_after_close_still_work(self):
+        # Verified diskcache 5.6.3 behavior: close() lazily reopens, ops
+        # keep working; SQLKVStore.close() is a documented no-op.
+        self.store.close()
+        self.store.set("k1", "v1")
+        self.assertEqual(self.store.get("k1"), "v1")
+
+    def test_double_close(self):
+        self.store.close()
+        self.store.close()  # must not raise on either backend
+
 
 class SQLBackendPurgeMixin:
     """Reset the SQL table before each test (shared-DB isolation)."""
@@ -243,6 +295,9 @@ class DiskCacheStoreTests(KVStoreContractBase, unittest.TestCase):
     def make_store(self):
         return DiskCacheStore(f"{self.tmpdir.name}/cache.db")
 
+    def make_second_store(self):
+        return DiskCacheStore(f"{self.tmpdir.name}/cache.db")
+
     def _purge(self):
         self.store._cache.clear()
 
@@ -251,6 +306,9 @@ class SQLiteKVStoreTests(
     SQLBackendPurgeMixin, SQLContractMixin, KVStoreContractBase, unittest.TestCase
 ):
     def make_store(self):
+        return SQLKVStore(f"sqlite:///{self.tmpdir.name}/kv.db")
+
+    def make_second_store(self):
         return SQLKVStore(f"sqlite:///{self.tmpdir.name}/kv.db")
 
     def test_engine_cached_by_result_storage_is_reused(self):
@@ -271,6 +329,9 @@ class DuckDBKVStoreTests(
     SQLBackendPurgeMixin, SQLContractMixin, KVStoreContractBase, unittest.TestCase
 ):
     def make_store(self):
+        return SQLKVStore(f"duckdb:///{self.tmpdir.name}/kv.duckdb")
+
+    def make_second_store(self):
         return SQLKVStore(f"duckdb:///{self.tmpdir.name}/kv.duckdb")
 
 
@@ -383,6 +444,77 @@ class SQLiteKVStoreConcurrencyTests(KVStoreConcurrencyBase, unittest.TestCase):
 class DuckDBKVStoreConcurrencyTests(KVStoreConcurrencyBase, unittest.TestCase):
     def make_store(self):
         return SQLKVStore(f"duckdb:///{self.tmpdir.name}/kv.duckdb")
+
+
+class SubprocessAddRaceTests(unittest.TestCase):
+    """Same-file multi-process add() race (the ZEO shape).
+
+    Three interpreter processes race on one SQLite file / diskcache
+    directory; add() must return True for exactly one of them. Gated on
+    ``RUN_PROCESS_TESTS=1`` — subprocess tests inside zope.testrunner are
+    deliberately not part of the default run.
+    """
+
+    _SCRIPT = (
+        "from zopyx.surveyjs.kv import DiskCacheStore, SQLKVStore\n"
+        "store = SQLKVStore({location!r}) if {backend!r} == 'sqlite' "
+        "else DiskCacheStore({location!r})\n"
+        "ok = store.add('race', 1)\n"
+        "store.close()\n"
+        "import sys\n"
+        "sys.stdout.write('1' if ok else '0')\n"
+    )
+
+    def _run_workers(self, backend, location, count=3):
+        # Use the buildout console script as interpreter: a bare python
+        # lacks the egg paths bin/test injects at startup, so zope imports
+        # would fail. bin/zopepy injects the full buildout egg path.
+        repo_root = Path(__file__).resolve().parents[4]
+        interpreter = str(repo_root / "bin" / "zopepy")
+        src_dir = str(Path(__file__).resolve().parents[3])
+        env = dict(os.environ)
+        env["PYTHONPATH"] = src_dir + os.pathsep + env.get("PYTHONPATH", "")
+        procs = [
+            subprocess.Popen(
+                [interpreter, "-c", self._SCRIPT.format(backend=backend, location=location)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env,
+            )
+            for _ in range(count)
+        ]
+        results = []
+        for proc in procs:
+            out, err = proc.communicate(timeout=60)
+            self.assertEqual(proc.returncode, 0, err.decode())
+            results.append(out.decode().strip())
+            if proc.stdout:
+                proc.stdout.close()
+            if proc.stderr:
+                proc.stderr.close()
+        return results
+
+    @unittest.skipUnless(
+        os.environ.get("RUN_PROCESS_TESTS") == "1", "RUN_PROCESS_TESTS=1 required"
+    )
+    def test_sqlite_subprocess_add_race(self):
+        with TemporaryDirectory() as td:
+            uri = f"sqlite:///{td}/race.db"
+            # Prime the table in-process so the subprocesses' create_all
+            # finds it and cannot race CREATE TABLE.
+            SQLKVStore(uri).close()
+            results = self._run_workers("sqlite", uri)
+            self.assertEqual(results.count("1"), 1, results)
+
+    @unittest.skipUnless(
+        os.environ.get("RUN_PROCESS_TESTS") == "1", "RUN_PROCESS_TESTS=1 required"
+    )
+    def test_diskcache_subprocess_add_race(self):
+        with TemporaryDirectory() as td:
+            path = f"{td}/cache.db"
+            DiskCacheStore(path).close()
+            results = self._run_workers("diskcache", path)
+            self.assertEqual(results.count("1"), 1, results)
 
 
 class FactoryTests(unittest.TestCase):

--- a/src/zopyx/surveyjs/tests/test_kv.py
+++ b/src/zopyx/surveyjs/tests/test_kv.py
@@ -1,0 +1,377 @@
+# -*- coding: utf-8 -*-
+"""Contract and deviation tests for the KV store facade.
+
+Runs the same behavioral contract against the diskcache wrapper and the
+SQLite-backed implementation, plus backend-specific deviation tests
+(JSON-only values, key-length limit, expired-key iteration/purge) and
+bounded thread-race coverage.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from zopyx.surveyjs.kv import DiskCacheStore, SQLKVStore, get_kv_store
+from zopyx.surveyjs.storage import SQLResultStorage
+
+
+class KVStoreContractBase:
+    """Common behavioral contract; concrete backend classes combine this
+    mixin with ``unittest.TestCase`` so the base itself is never collected
+    by the test runner."""
+
+    def make_store(self):
+        raise NotImplementedError
+
+    def setUp(self):
+        self.tmpdir = TemporaryDirectory()
+        self.store = self.make_store()
+        self.addCleanup(self._close_store)
+
+    def _close_store(self):
+        try:
+            self.store.close()
+        except Exception:
+            pass
+        # Dispose the (per-test, cached) engine so the SQLAlchemy pool
+        # releases its sqlite3 handles (no ResourceWarning noise).
+        engine = getattr(self.store, "_engine", None)
+        if engine is not None:
+            try:
+                engine.dispose()
+            except Exception:
+                pass
+        self.tmpdir.cleanup()
+
+    def _wait_until_expired(self, key, timeout=3.0):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if self.store.get(key) is None:
+                return True
+            time.sleep(0.02)
+        return self.store.get(key) is None
+
+    # -- set/get --------------------------------------------------------
+
+    def test_string_roundtrip(self):
+        self.store.set("k1", "v1")
+        self.assertEqual(self.store.get("k1"), "v1")
+
+    def test_nested_dict_roundtrip(self):
+        value = {"a": [1, 2, {"b": None}], "c": {"d": "δ-🚴"}}
+        self.store.set("k1", value)
+        self.assertEqual(self.store.get("k1"), value)
+
+    def test_missing_with_and_without_default(self):
+        self.assertIsNone(self.store.get("missing"))
+        self.assertEqual(self.store.get("missing", {"d": 1}), {"d": 1})
+
+    def test_set_overwrites(self):
+        self.store.set("k1", 1)
+        self.store.set("k1", 2)
+        self.assertEqual(self.store.get("k1"), 2)
+
+    def test_unicode_key_roundtrip(self):
+        self.store.set("schlüssel-🚴-δ", {"ok": True})
+        self.assertEqual(self.store.get("schlüssel-🚴-δ"), {"ok": True})
+
+    # -- add ------------------------------------------------------------
+
+    def test_add_once_preserves_first_value(self):
+        self.assertTrue(self.store.add("k1", "first"))
+        self.assertFalse(self.store.add("k1", "second"))
+        self.assertEqual(self.store.get("k1"), "first")
+
+    def test_add_after_delete(self):
+        self.assertTrue(self.store.add("k1", "v1"))
+        self.store.delete("k1")
+        self.assertTrue(self.store.add("k1", "v2"))
+        self.assertEqual(self.store.get("k1"), "v2")
+
+    def test_expired_key_can_be_added_again(self):
+        self.store.set("k1", "old", expire=0.05)
+        self.assertTrue(self._wait_until_expired("k1"))
+        self.assertTrue(self.store.add("k1", "new"))
+        self.assertEqual(self.store.get("k1"), "new")
+
+    # -- delete ---------------------------------------------------------
+
+    def test_delete_idempotent(self):
+        self.store.set("k1", "v1")
+        self.store.delete("k1")
+        self.store.delete("k1")  # must not raise
+        self.assertIsNone(self.store.get("k1"))
+
+    # -- iterkeys -------------------------------------------------------
+
+    def test_iterkeys_all_live_keys_and_prefix_filter(self):
+        self.store.set("sub:1", 1)
+        self.store.set("sub:2", 2)
+        self.store.set("form:1", 3)
+        self.assertEqual(
+            sorted(self.store.iterkeys()), ["form:1", "sub:1", "sub:2"]
+        )
+        self.assertEqual(
+            sorted(k for k in self.store.iterkeys() if k.startswith("sub:")),
+            ["sub:1", "sub:2"],
+        )
+
+    # -- TTL ------------------------------------------------------------
+
+    def test_expire_none_persists(self):
+        self.store.set("k1", "v1")
+        self.assertEqual(self.store.get("k1"), "v1")
+
+    def test_zero_and_negative_expiry_missing(self):
+        self.store.set("z", "v", expire=0)
+        self.assertIsNone(self.store.get("z"))
+        self.store.set("n", "v", expire=-1)
+        self.assertIsNone(self.store.get("n"))
+
+    def test_short_positive_expiry_expires(self):
+        self.store.set("k1", "v1", expire=0.1)
+        self.assertEqual(self.store.get("k1"), "v1")
+        self.assertTrue(self._wait_until_expired("k1"))
+        self.assertIsNone(self.store.get("k1"))
+
+    def test_set_refreshes_expiry(self):
+        self.store.set("k1", "v1", expire=0.05)
+        self.store.set("k1", "v2", expire=60)
+        time.sleep(0.1)
+        self.assertEqual(self.store.get("k1"), "v2")
+
+    def test_set_removes_expiry_with_none(self):
+        self.store.set("k1", "v1", expire=0.05)
+        self.store.set("k1", "v2")
+        time.sleep(0.1)
+        self.assertEqual(self.store.get("k1"), "v2")
+
+    # -- value fidelity ------------------------------------------------
+
+    def test_value_fidelity(self):
+        cases = [
+            None,
+            True,
+            1,
+            {},
+            [],
+            "",
+            "unicode-δ-🚴",
+            {"nested": {"a": [1, 2, {"b": None}]}},
+        ]
+        for index, value in enumerate(cases):
+            key = f"v{index}"
+            self.store.set(key, value)
+            self.assertEqual(self.store.get(key), value)
+
+    def test_bool_and_int_stay_distinct(self):
+        self.store.set("b", True)
+        self.store.set("i", 1)
+        self.assertIs(self.store.get("b"), True)
+        self.assertEqual(self.store.get("i"), 1)
+
+    def test_large_payload_roundtrip(self):
+        payload = {"data": "x" * 100_000}
+        self.store.set("big", payload)
+        self.assertEqual(self.store.get("big"), payload)
+
+
+class DiskCacheStoreTests(KVStoreContractBase, unittest.TestCase):
+    """The diskcache wrapper must preserve diskcache behavior."""
+
+    def make_store(self):
+        return DiskCacheStore(f"{self.tmpdir.name}/cache.db")
+
+
+class SQLKVStoreTests(KVStoreContractBase, unittest.TestCase):
+    """SQLite-backed store: common contract plus SQL deviations."""
+
+    def make_store(self):
+        return SQLKVStore(f"sqlite:///{self.tmpdir.name}/kv.db")
+
+    # -- SQL-specific edge cases ---------------------------------------
+
+    def test_key_exactly_255_chars(self):
+        key = "k" * 255
+        self.store.set(key, "v")
+        self.assertEqual(self.store.get(key), "v")
+
+    def test_overlong_key_rejected_by_all_methods(self):
+        key = "k" * 256
+        with self.assertRaises(ValueError):
+            self.store.set(key, "v")
+        with self.assertRaises(ValueError):
+            self.store.add(key, "v")
+        with self.assertRaises(ValueError):
+            self.store.get(key)
+        with self.assertRaises(ValueError):
+            self.store.delete(key)
+
+    def test_unsupported_value_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            self.store.set("k1", object())
+
+    def test_rejects_non_sqlite_uri(self):
+        with self.assertRaises(ValueError):
+            SQLKVStore("postgresql://user:pass@localhost:5432/db")
+
+    def test_engine_cached_by_result_storage_is_reused(self):
+        """Regression: an engine cached before the KV table existed must
+        still get the KV table created (explicit create_all on init)."""
+        uri = f"sqlite:///{self.tmpdir.name}/regress.db"
+        SQLResultStorage(uri)  # constructs+caches the engine, create_all
+        kv = SQLKVStore(uri)
+        kv.set("k1", {"ok": True})
+        self.assertEqual(kv.get("k1"), {"ok": True})
+
+    def test_iterkeys_excludes_expired_rows(self):
+        self.store.set("old", "v", expire=-1)
+        self.store.set("new", "v", expire=60)
+        self.assertEqual(sorted(self.store.iterkeys()), ["new"])
+
+
+class KVStoreConcurrencyBase:
+    """Bounded thread-race coverage for the atomic add() primitive.
+
+    Mixin only; concrete backend classes combine it with
+    ``unittest.TestCase`` so the base is never collected.
+    """
+
+    def make_store(self):
+        raise NotImplementedError
+
+    def setUp(self):
+        self.tmpdir = TemporaryDirectory()
+        self.store = self.make_store()
+        self.addCleanup(self._close_store)
+
+    def _close_store(self):
+        try:
+            self.store.close()
+        except Exception:
+            pass
+        # Dispose the (per-test, cached) engine so the SQLAlchemy pool
+        # releases its sqlite3 handles (no ResourceWarning noise).
+        engine = getattr(self.store, "_engine", None)
+        if engine is not None:
+            try:
+                engine.dispose()
+            except Exception:
+                pass
+        self.tmpdir.cleanup()
+
+    def test_add_race_exactly_one_winner(self):
+        results = []
+        errors = []
+        lock = threading.Lock()
+        barrier = threading.Barrier(8)
+
+        def worker(index):
+            try:
+                barrier.wait(timeout=5)
+                ok = self.store.add("race", index)
+                with lock:
+                    results.append((index, ok))
+            except Exception as exc:  # noqa: BLE001 - collected for assertion
+                with lock:
+                    errors.append(exc)
+            finally:
+                # diskcache keeps a per-thread connection; each thread that
+                # accesses the cache must close it (diskcache usage contract).
+                try:
+                    self.store.close()
+                except Exception:
+                    pass
+
+        threads = [
+            threading.Thread(target=worker, args=(index,)) for index in range(8)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=30)
+
+        self.assertEqual(errors, [])
+        winners = [index for index, ok in results if ok]
+        self.assertEqual(len(winners), 1)
+        stored = self.store.get("race")
+        self.assertIn(stored, [index for index, _ in results])
+
+    def test_concurrent_independent_keys(self):
+        errors = []
+
+        def worker(base):
+            try:
+                for index in range(25):
+                    key = f"{base}:{index}"
+                    self.store.set(key, index)
+                    if self.store.get(key) != index:
+                        raise AssertionError(f"roundtrip failed for {key}")
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+            finally:
+                # diskcache keeps a per-thread connection; each thread that
+                # accesses the cache must close it (diskcache usage contract).
+                try:
+                    self.store.close()
+                except Exception:
+                    pass
+
+        threads = [
+            threading.Thread(target=worker, args=(f"t{n}",)) for n in range(4)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=60)
+
+        self.assertEqual(errors, [])
+
+
+class DiskCacheStoreConcurrencyTests(KVStoreConcurrencyBase, unittest.TestCase):
+    def make_store(self):
+        return DiskCacheStore(f"{self.tmpdir.name}/cache.db")
+
+
+class SQLKVStoreConcurrencyTests(KVStoreConcurrencyBase, unittest.TestCase):
+    def make_store(self):
+        return SQLKVStore(f"sqlite:///{self.tmpdir.name}/kv.db")
+
+
+class FactoryTests(unittest.TestCase):
+    def test_diskcache_factory(self):
+        with TemporaryDirectory() as td:
+            store = get_kv_store("diskcache", f"{td}/c.db")
+            self.assertIsInstance(store, DiskCacheStore)
+            store.set("k1", "v1")
+            self.assertEqual(store.get("k1"), "v1")
+            store.close()
+
+    def test_sqlite_factory(self):
+        with TemporaryDirectory() as td:
+            store = get_kv_store("sqlite", f"sqlite:///{td}/kv.db")
+            self.assertIsInstance(store, SQLKVStore)
+            store.set("k1", "v1")
+            self.assertEqual(store.get("k1"), "v1")
+            store.close()
+            engine = getattr(store, "_engine", None)
+            if engine is not None:
+                engine.dispose()
+
+    def test_unknown_backend_raises(self):
+        with self.assertRaises(ValueError):
+            get_kv_store("redis", "/tmp/x.db")
+
+    def test_empty_location_raises(self):
+        with self.assertRaises(ValueError):
+            get_kv_store("diskcache", "")
+
+    def test_timeout_zero_reaches_diskcache_unchanged(self):
+        with patch("zopyx.surveyjs.kv.diskcache.Cache") as mock_cache:
+            get_kv_store("diskcache", "/tmp/x.db", timeout=0)
+            mock_cache.assert_called_once_with("/tmp/x.db", timeout=0)

--- a/src/zopyx/surveyjs/tests/test_kv_db_containers.py
+++ b/src/zopyx/surveyjs/tests/test_kv_db_containers.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+"""PostgreSQL and MySQL contract runs for the KV store facade.
+
+Reuses the shared contract, SQL edge-case and concurrency mixins from
+``test_kv`` against real database servers started via testcontainers
+(Docker). Every class here is skipped unless ``RUN_DB_CONTAINER_TESTS=1``
+so the suite never fails on machines without Docker.
+
+Note: zope.testrunner does not call ``setUpClass``/``tearDownClass``, so
+the shared store is created lazily in ``make_store`` (class attribute) and
+containers are reaped by testcontainers' ryuk on process exit.
+
+CI (``.github/workflows/tests.yml``) sets the env var and pre-pulls the
+images; locally run with::
+
+    RUN_DB_CONTAINER_TESTS=1 bin/test -s zopyx.surveyjs -t test_kv_db_containers
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from sqlalchemy import delete
+
+from zopyx.surveyjs.kv import KVEntry, SQLKVStore
+
+from .test_kv import (
+    KVStoreConcurrencyBase,
+    KVStoreContractBase,
+    SQLBackendPurgeMixin,
+    SQLContractMixin,
+)
+
+RUN_CONTAINER_TESTS = os.environ.get("RUN_DB_CONTAINER_TESTS") == "1"
+
+_POSTGRES_URI = None
+_MYSQL_URI = None
+
+
+def _get_postgres_uri() -> str:
+    global _POSTGRES_URI
+    if _POSTGRES_URI is None:
+        from testcontainers.community.postgres import PostgresContainer
+
+        _POSTGRES_URI = PostgresContainer("postgres:16").start().get_connection_url()
+    return _POSTGRES_URI
+
+
+def _get_mysql_uri() -> str:
+    global _MYSQL_URI
+    if _MYSQL_URI is None:
+        from testcontainers.community.mysql import MySqlContainer
+
+        container = MySqlContainer("mysql:8").start()
+        _MYSQL_URI = (
+            f"mysql+pymysql://{container.username}:{container.password}@"
+            f"{container.get_container_host_ip()}:{container.get_exposed_port(3306)}/"
+            f"{container.dbname}"
+        )
+    return _MYSQL_URI
+
+
+def _purge_store(store) -> None:
+    with store._session() as session:
+        session.execute(delete(KVEntry))
+        session.commit()
+
+
+@unittest.skipUnless(RUN_CONTAINER_TESTS, "RUN_DB_CONTAINER_TESTS=1 required")
+class PostgresKVStoreTests(
+    SQLBackendPurgeMixin, SQLContractMixin, KVStoreContractBase, unittest.TestCase
+):
+    _shared = None
+
+    def make_store(self):
+        if type(self)._shared is None:
+            type(self)._shared = SQLKVStore(_get_postgres_uri())
+        return type(self)._shared
+
+
+@unittest.skipUnless(RUN_CONTAINER_TESTS, "RUN_DB_CONTAINER_TESTS=1 required")
+class MySqlKVStoreTests(
+    SQLBackendPurgeMixin, SQLContractMixin, KVStoreContractBase, unittest.TestCase
+):
+    _shared = None
+
+    def make_store(self):
+        if type(self)._shared is None:
+            type(self)._shared = SQLKVStore(_get_mysql_uri())
+        return type(self)._shared
+
+
+@unittest.skipUnless(RUN_CONTAINER_TESTS, "RUN_DB_CONTAINER_TESTS=1 required")
+class PostgresKVStoreConcurrencyTests(KVStoreConcurrencyBase, unittest.TestCase):
+    _shared = None
+
+    def make_store(self):
+        if type(self)._shared is None:
+            type(self)._shared = SQLKVStore(_get_postgres_uri())
+        return type(self)._shared
+
+
+@unittest.skipUnless(RUN_CONTAINER_TESTS, "RUN_DB_CONTAINER_TESTS=1 required")
+class MySqlKVStoreConcurrencyTests(KVStoreConcurrencyBase, unittest.TestCase):
+    _shared = None
+
+    def make_store(self):
+        if type(self)._shared is None:
+            type(self)._shared = SQLKVStore(_get_mysql_uri())
+        return type(self)._shared

--- a/src/zopyx/surveyjs/tests/test_kv_db_containers.py
+++ b/src/zopyx/surveyjs/tests/test_kv_db_containers.py
@@ -78,6 +78,10 @@ class PostgresKVStoreTests(
             type(self)._shared = SQLKVStore(_get_postgres_uri())
         return type(self)._shared
 
+    def make_second_store(self):
+        # Same URI -> same cached engine; "reopen" is a new store instance.
+        return SQLKVStore(_get_postgres_uri())
+
 
 @unittest.skipUnless(RUN_CONTAINER_TESTS, "RUN_DB_CONTAINER_TESTS=1 required")
 class MySqlKVStoreTests(
@@ -89,6 +93,9 @@ class MySqlKVStoreTests(
         if type(self)._shared is None:
             type(self)._shared = SQLKVStore(_get_mysql_uri())
         return type(self)._shared
+
+    def make_second_store(self):
+        return SQLKVStore(_get_mysql_uri())
 
 
 @unittest.skipUnless(RUN_CONTAINER_TESTS, "RUN_DB_CONTAINER_TESTS=1 required")


### PR DESCRIPTION
## Summary

Adds the KV store facade (`src/zopyx/surveyjs/kv.py`) that mirrors the diskcache API surface used by the add-on (set/add/get/iterkeys/delete/close with TTL), with two implementation families and an intensive cross-storage test suite:

- `DiskCacheStore` — 1:1 pass-through over diskcache.Cache
- `SQLKVStore` — SQLAlchemy-backed, tested against SQLite, DuckDB, PostgreSQL 16 and MySQL 8

## Key design points

- Atomic `add()`: INSERT + conditional UPDATE on conflict (expired rows only), dialect-appropriate success signal (UPDATE...RETURNING for sqlite/duckdb/postgres, rowcount for MySQL); never read-then-write
- Expiry stored as UTC epoch `Double` (Float compiles to 32-bit FLOAT on DuckDB/MySQL and loses precision — caught by the portability tests)
- Key validation in the facade (255 code points); JSON-only values via orjson; LONGTEXT variant for MySQL
- `get_kv_store(backend, path_or_uri, timeout)` factory; no implicit cwd-relative defaults
- Documented deviations pinned by tests (JSON-not-pickle, expired-key iteration/purge, key limit, no-op SQL close)

## Tests

- Shared contract (24 tests) + SQL edge mixin + concurrency (threads and multi-process ZEO shape) run against all five backends
- PostgreSQL/MySQL via testcontainers, gated on `RUN_DB_CONTAINER_TESTS=1` (enabled in CI with image pre-pull)
- Full matrix: 161 tests, 0 failures, 0 skipped; `make test`: 438 tests, 0 failures

## Not in scope (follow-up)

Wiring auth/embed/monitoring call sites onto the facade (registry settings, per-store backend choice, cwd-relative path fixes) — separate plan.